### PR TITLE
Add opacity prop with default value of 0.84

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"

--- a/src/IconBase.js
+++ b/src/IconBase.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const IconBase = ({ children, color, size, style, width, height, ...props }) => {
+const IconBase = ({ children, color, size, style, width, height, opacity, ...props }) => {
   const computedSize = size || '1em';
   return (
     <svg
@@ -12,6 +12,7 @@ const IconBase = ({ children, color, size, style, width, height, ...props }) => 
       width={width || computedSize}
       {...props}
       style={{
+        opacity: opacity || 0.84,
         verticalAlign: 'middle',
         color,
         ...style,
@@ -25,6 +26,7 @@ IconBase.propTypes = {
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  opacity: PropTypes.number,
   style: PropTypes.object,
 };
 

--- a/src/IconBase.js
+++ b/src/IconBase.js
@@ -12,7 +12,7 @@ const IconBase = ({ children, color, size, style, width, height, opacity, ...pro
       width={width || computedSize}
       {...props}
       style={{
-        opacity: opacity || 0.84,
+        opacity: opacity || '0.84',
         verticalAlign: 'middle',
         color,
         ...style,

--- a/src/IconBase.js
+++ b/src/IconBase.js
@@ -12,7 +12,7 @@ const IconBase = ({ children, color, size, style, width, height, opacity, ...pro
       width={width || computedSize}
       {...props}
       style={{
-        opacity: opacity || '0.84',
+        opacity,
         verticalAlign: 'middle',
         color,
         ...style,
@@ -28,6 +28,10 @@ IconBase.propTypes = {
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   opacity: PropTypes.number,
   style: PropTypes.object,
+};
+
+IconBase.defaultProps = {
+  opacity: 0.84,
 };
 
 export default IconBase;


### PR DESCRIPTION
## Purpose
Because the current icons have a little too much contrast, we decided icons should have an opacity prop with a default of **0.84**.

**Todo:** version bump before making new release

## Breaking changes
none