### PR TITLE
Fix: Update node/npm constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
+## [unreleased]
+
+### Added
+
+### Changed
+
+- Loosen engine constraints to allow node version > 8 and npm versions > 5 ([@rathesDot](https://github.com/rathesDot) in [#63](https://github.com/teamleadercrm/ui/pull/63))
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Dependency updates
+
 ## [0.2.19] - 2019-08-08
+
 ### Added
 
 - 14x14_cols_outline.svg
@@ -15,6 +32,7 @@
 - `fs-extra` from `^4.0.2` to `^8.1.0`
 
 ### Dependency replacements
+
 - `lodash.camelcase@^4.3.0` replaced by `lodash@^4.17.14`
 - `lodash.findkey@^4.6.0` replaced by `lodash@^4.17.14`
 - `lodash.upperfirst@^4.3.1` replaced by `lodash@^4.17.14`

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "^1.16.4"
   },
   "engines": {
-    "node": "^8.0.0",
+    "node": ">=8.0.0",
     "npm": "^5.0.0"
   },
   "homepage": "https://github.com/teamleadercrm/ui-icons#readme",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "engines": {
     "node": ">=8.0.0",
-    "npm": "^5.0.0"
+    "npm": ">=5.0.0"
   },
   "homepage": "https://github.com/teamleadercrm/ui-icons#readme",
   "keywords": [


### PR DESCRIPTION
This PR loosens the engine constraints. Before now everything above node 8 and npm 5 is denied (so you have to add `--ignore-engines` all the time.

After this PR all newer major versions are accepted as well.

## Question: Does this need to be added to the changelog?