### PR TITLE
Release 0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- Loosen engine constraints to allow node version > 8 and npm versions > 5 ([@rathesDot](https://github.com/rathesDot) in [#63](https://github.com/teamleadercrm/ui/pull/63))
-
 ### Deprecated
 
 ### Removed
@@ -13,6 +11,18 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.2.20] - 2019-09-09
+
+### Changed
+
+- Loosen engine constraints to allow node version > 8 and npm versions > 5 ([@rathesDot](https://github.com/rathesDot) in [#63](https://github.com/teamleadercrm/ui/pull/63))
+
+### Dependency updates
+
+- `@babel/cli` from `^7.5.5` to `^7.6.0`
+- `@babel/core` from `^7.5.5` to `^7.6.0`
+- `@babel/preset-env` from `^7.5.5` to `^7.6.0`
 
 ## [0.2.19] - 2019-08-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"


### PR DESCRIPTION
### Changed

- Loosen engine constraints to allow node version > 8 and npm versions > 5 ([@rathesDot](https://github.com/rathesDot) in [#63](https://github.com/teamleadercrm/ui/pull/63))

### Dependency updates

- `@babel/cli` from `^7.5.5` to `^7.6.0`
- `@babel/core` from `^7.5.5` to `^7.6.0`
- `@babel/preset-env` from `^7.5.5` to `^7.6.0`
