### PR TITLE
Release 0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,30 @@
 
 ### Changed
 
-- `Build process & dependency resolution`: changed from npm to yarn, added yarn.lock ([@driesd](https://github.com/driesd) in [#143](https://github.com/teamleadercrm/ui-icons/pull/143))
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+### Dependency updates
+
+## [0.2.26] 2020-03-25
+
+### Changed
+
+- 14x14_team-outline.svg ([@driesd](https://github.com/driesd) in [#140](https://github.com/teamleadercrm/ui-icons/pull/140)) 
+- `Build process & dependency resolution`: changed from npm to yarn, added yarn.lock ([@driesd](https://github.com/driesd) in [#143](https://github.com/teamleadercrm/ui-icons/pull/143))
+
+### Dependency updates
+
+- `fs-extra` from `8.1.0` to `9.0.0`
+- `@babel/register` from `7.8.6` to `7.9.0`
+- `@babel/preset-env` from `7.8.7` to `7.9.0`
+- `@babel/core` from `7.8.7` to `7.9.0`
+- `@babel/plugin-transform-runtime` from `7.8.3` to `7.9.0`
+- `@babel/preset-react` from `7.8.3` to `7.9.4`
+- `prettier` from `1.19.1` to `2.0.2`
 
 ## [0.2.25] 2020-03-23
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"


### PR DESCRIPTION
### Changed

- 14x14_team-outline.svg ([@driesd](https://github.com/driesd) in [#140](https://github.com/teamleadercrm/ui-icons/pull/140)) 
- `Build process & dependency resolution`: changed from npm to yarn, added yarn.lock ([@driesd](https://github.com/driesd) in [#143](https://github.com/teamleadercrm/ui-icons/pull/143))

### Dependency updates

- `fs-extra` from `8.1.0` to `9.0.0`
- `@babel/register` from `7.8.6` to `7.9.0`
- `@babel/preset-env` from `7.8.7` to `7.9.0`
- `@babel/core` from `7.8.7` to `7.9.0`
- `@babel/plugin-transform-runtime` from `7.8.3` to `7.9.0`
- `@babel/preset-react` from `7.8.3` to `7.9.4`
- `prettier` from `1.19.1` to `2.0.2`
