### PR TITLE
Add react 17 as a valid peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+### Dependency updates
+
+## [1.1.0] 2021-03-16
+
+### Fixed
+
 - Wrong casing of lodash imports
 
 ### Dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Wrong casing of lodash imports
+
 ### Dependency updates
 
 - Add React 17 as a valid peer dependency version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Dependency updates
 
+- Add React 17 as a valid peer dependency version
+
 ## [1.0.1] 2021-03-15
 
 ### Fixed

--- a/bin/create.js
+++ b/bin/create.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const Promise = require('bluebird');
 const cheerio = require('cheerio');
-const camelCase = require('lodash/camelcase');
-const upperFirst = require('lodash/upperfirst');
-const findKey = require('lodash/findkey');
+const camelCase = require('lodash/camelCase');
+const upperFirst = require('lodash/upperFirst');
+const findKey = require('lodash/findKey');
 const fs = Promise.promisifyAll(require('fs-extra'));
 const { globAsync } = Promise.promisifyAll(require('glob'));
 const svgToJsx = require('@balajmarius/svg2jsx');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "cjs/index.js",
   "module": "es/index.js",
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "private": false,
   "repository": {


### PR DESCRIPTION
- add react 17 as a valid peer dependency
- fix lodash imports (only noticeable on case-sensitive file systems)
- bump version from 1.0.1 to 1.1.0