### PR TITLE
Release/1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ### Added
 
-- 24x24_rocket_filled.svg
-- 24x24_rocket_outline.svg
-
 ### Changed
 
 ### Deprecated
@@ -14,6 +11,21 @@
 ### Fixed
 
 ### Dependency updates
+
+## [1.7.0] 2021-11-10
+
+### Added
+
+- 24x24_rocket_filled.svg
+- 24x24_rocket_outline.svg
+
+### Dependency updates
+
+- `glob` from `7.1.7` to `7.2.0`
+- `@babel/cli ` from `7.14.8` to `7.15.7`
+- `prettier` from `2.3.2` to `2.4.1`
+- `@babel/preset-env` from `7.15.0` to `7.15.6`
+- `@babel/core` from `7.15.0` to `7.15.5`
 
 ## [1.6.0] 2021-09-02
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"


### PR DESCRIPTION
## [1.7.0] 2021-11-10

### Added

- 24x24_rocket_filled.svg
- 24x24_rocket_outline.svg

### Dependency updates

- `glob` from `7.1.7` to `7.2.0`
- `@babel/cli ` from `7.14.8` to `7.15.7`
- `prettier` from `2.3.2` to `2.4.1`
- `@babel/preset-env` from `7.15.0` to `7.15.6`
- `@babel/core` from `7.15.0` to `7.15.5`

