### PR TITLE
Include icon svgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Also expose icon svgs directly for use in non-react packages
+
 ### Changed
 
 ### Deprecated
@@ -15,6 +17,7 @@
 ## [1.8.0] 2022-05-23
 
 ### Added
+
 - 24x24_unlink_outline.svg
 
 - 24x24_schedule_filled.svg

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
   "license": "MIT",
   "main": "cjs/index.js",
   "module": "es/index.js",
+  "files": [
+    "cjs",
+    "es",
+    "icons"
+  ],
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },


### PR DESCRIPTION
Also include the icon svgs so they can be used in non-react packages.

You can import an icon directly as follows:
```
import addBadgedFilled from '@teamleader/ui-icons/icons/14x14_add_badged_filled.svg';

// ...

<img src={addBadgedFilled} />
```

This works fine when testing locally using `yarn link`, but that just symlinks it so we'll have to see if it also works in practice