### PR TITLE
Release/2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Removed
 
+### Fixed
+
+### Dependency updates
+
+## [2.0.1] 2022-08-01
+
+### Removed
+
 - 24x24_picture_in_picture_alt_outline 1.svg
 
 ### Fixed
@@ -16,8 +24,6 @@
 - renamed 24x24_marker_outline 1.svg to 24x24_marker_outline.svg
 - renamed 24x24_refresh_outline.svg to 24x24_refresh_alt_outline.svg
 - renamed 24x24_refresh_outline 1.svg to 24x24_refresh_outline.svg
-
-### Dependency updates
 
 ## [2.0.0] 2022-07-27
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"


### PR DESCRIPTION
## [2.0.1] 2022-08-01

### Removed

- 24x24_picture_in_picture_alt_outline 1.svg

### Fixed

- renamed 24x24_marker_outline.svg to 24x24_highlighter_outline.svg
- renamed 24x24_marker_outline 1.svg to 24x24_marker_outline.svg
- renamed 24x24_refresh_outline.svg to 24x24_refresh_alt_outline.svg
- renamed 24x24_refresh_outline 1.svg to 24x24_refresh_outline.svg