### PR TITLE
Remove viewbox property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Remove `viewBox` attribute since it's always undefined.
+
 ### Dependency updates
 
 ## [2.0.1] 2022-08-01

--- a/bin/create.js
+++ b/bin/create.js
@@ -35,15 +35,13 @@ const transformSVGToReactComponent = Promise.coroutine(function*(rawSVG, compone
     }
   });
 
-  const viewBox = $svg.attr('viewBox');
-
   // Actual output of the React component
   return `
             import React from 'react';
             import Icon from './IconBase';
             
             const ${componentName} = props => (
-              <Icon viewBox="${viewBox}" {...props} width="${width}" height="${height}">
+              <Icon {...props} width="${width}" height="${height}">
                 ${$svg.html()}
               </Icon>
             );


### PR DESCRIPTION
None of our icons have a viewbox attribute anymore so let's just remove it as this causes these kind of errors
<img width="586" alt="image" src="https://user-images.githubusercontent.com/1833617/185883161-482d1ce7-747c-46b6-9af6-980aa2b7ebef.png">
