### PR TITLE
Fix 14x14_percentage_up.svg dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [2.8.2] 2023-09-21
+
+### Fixed
+
+- Ensure 14x14_percentage_up dimensions are equal for both width and height.
+
 ## [2.8.0] 2023-09-21
 
 ### Added

--- a/icons/14x14_percentage_up.svg
+++ b/icons/14x14_percentage_up.svg
@@ -1,3 +1,3 @@
-<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M2 10L4.79289 7.20711C5.18342 6.81658 5.81658 6.81658 6.20711 7.20711L7.29289 8.29289C7.68342 8.68342 8.31658 8.68342 8.70711 8.29289L13 4M13 4H10M13 4V7" stroke="#1A1C20" stroke-linecap="round"/>
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-icons",
   "description": "Teamleader UI icons",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-icons/issues"


### PR DESCRIPTION
## [2.8.2] 2023-09-21

### Fixed

- Ensure 14x14_percentage_up dimensions are equal for both width and height.